### PR TITLE
feat: add web-applications topic

### DIFF
--- a/topics/web-applications
+++ b/topics/web-applications
@@ -1,0 +1,1 @@
+This topic lists packages used primarly for web-based application development in R. Examples include packages enhacning the Shiny framework and packages used to create custom http-based APIs.


### PR DESCRIPTION
This PR adds a new topic dedicated to packages addressing web-application development. While many of the packages involved in this topic will likely be intertwined with Shiny, I wanted to make sure other packages strictly for web-based API development could fit in this topic. Happy to collaborate if there is a more appropriate name for this topic.